### PR TITLE
Added attachments handling to ImpersonateMessage

### DIFF
--- a/src/Stampie/Extra/Message/Decorator.php
+++ b/src/Stampie/Extra/Message/Decorator.php
@@ -3,6 +3,7 @@
 namespace Stampie\Extra\Message;
 
 use Stampie\MessageInterface;
+use Stampie\Message\AttachmentsAwareInterface;
 use Stampie\Message\MetadataAwareInterface;
 use Stampie\Message\TaggableInterface;
 
@@ -13,7 +14,7 @@ use Stampie\Message\TaggableInterface;
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-class Decorator implements MessageInterface, TaggableInterface, MetadataAwareInterface
+class Decorator implements MessageInterface, TaggableInterface, MetadataAwareInterface, AttachmentsAwareInterface
 {
     protected $delegate;
 
@@ -113,6 +114,18 @@ class Decorator implements MessageInterface, TaggableInterface, MetadataAwareInt
     {
         if ($this->delegate instanceof MetadataAwareInterface) {
             return $this->delegate->getMetadata();
+        }
+
+        return array();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAttachments()
+    {
+        if ($this->delegate instanceof AttachmentsAwareInterface) {
+            return $this->delegate->getAttachments();
         }
 
         return array();

--- a/src/Stampie/Extra/Message/ImpersonateMessage.php
+++ b/src/Stampie/Extra/Message/ImpersonateMessage.php
@@ -2,7 +2,6 @@
 
 namespace Stampie\Extra\Message;
 
-use Stampie\Message\AttachmentsAwareInterface;
 use Stampie\MessageInterface;
 use Stampie\Util\IdentityUtils;
 
@@ -11,7 +10,7 @@ use Stampie\Util\IdentityUtils;
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-class ImpersonateMessage extends Decorator implements AttachmentsAwareInterface
+class ImpersonateMessage extends Decorator
 {
     private $recipient;
 
@@ -35,15 +34,6 @@ class ImpersonateMessage extends Decorator implements AttachmentsAwareInterface
     public function getBcc()
     {
         return null;
-    }
-
-    public function getAttachments()
-    {
-        if ($this->delegate instanceof AttachmentsAwareInterface) {
-            return $this->delegate->getAttachments();
-        }
-
-        return array();
     }
 
     public function getHeaders()


### PR DESCRIPTION
This adds the handling of Attachements to the ImpersonateMessage class, after merging https://github.com/henrikbjorn/Stampie/pull/36.

In order not to break anything, I have to be sure that `"henrikbjorn/stampie": "~0.7",` gets the update, which is not the case at the moment. A tag issue perhaps, as discussed on [Stampie](https://github.com/henrikbjorn/Stampie/pull/36#issuecomment-49405064).

AFAIK, this should wait for the new tag, just to be sure.
