### PR TITLE
Improve the CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,13 @@ matrix:
 
           # Test the latest stable release
         - php: 5.5
+          dist: trusty
         - php: 5.6
         - php: 7.0
         - php: 7.1
         - php: 7.2
           env: COVERAGE=true PHPUNIT_FLAGS="--coverage-clover=coverage.clover"
+        - php: 7.3
 
           # Test each Symfony major versions. This makes sure we do not use Symfony packages with version greater
           # than 2 or 3 respectively. Read more at https://github.com/symfony/lts
@@ -34,7 +36,7 @@ matrix:
           env: DEPENDENCIES="dunglas/symfony-lock:^4
 
           # Latest commit to master
-        - php: 7.2
+        - php: 7.3
           env: STABILITY="dev"
 
           # Test master with nightly PHP
@@ -54,11 +56,10 @@ install:
     # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
     - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable; fi
     - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
-    - ./vendor/bin/simple-phpunit install
 
 script:
     - composer validate --strict --no-check-lock
-    - ./vendor/bin/simple-phpunit -v $PHPUNIT_FLAGS
+    - ./vendor/bin/phpunit -v $PHPUNIT_FLAGS
 
 after_success:
     - if [[ $COVERAGE = true ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
     },
     "require" : {
         "php": "^5.5 || ^7.0",
-        "stampie/stampie": "^1.0@beta",
+        "stampie/stampie": "^1.0",
         "symfony/event-dispatcher": "^2.3 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.1",
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.1 || ^7.5",
         "php-http/mock-client": "^1.0",
         "psr/log": "^1.0",
-        "symfony/phpunit-bridge": "^3.2 || ^4"
+        "symfony/phpunit-bridge": "^4.3"
     },
     "conflict": {
         "stof/stampie-extra": "*"


### PR DESCRIPTION
- add testing on PHP 7.3
- force using a recent version of the PHPUnit bridge
- use the locally required version of PHPUnit to run tests
- add support for installing PHPUnit 7
- force using the trusty dist for PHP 5.5 on Travis, as xenial is now the default but only supports PHP 5.6+.